### PR TITLE
不具合の修正とその他軽微な変更

### DIFF
--- a/bot/main.py
+++ b/bot/main.py
@@ -3,6 +3,7 @@ from dotenv import load_dotenv, find_dotenv
 import discord
 from discord.ext import bridge
 import pkgutil, importlib
+import datetime as dt
 
 # 更新チェックループ
 from bot.utils.checker import start_update_loop
@@ -32,7 +33,7 @@ channel = None
 async def on_ready():
     global target_guild, channel
     # 起動ログ
-    print(f"Bot is ready. Guild/Channel: {TARGET_GUILD_ID}/{TARGET_CHANNEL_ID}")
+    print(f"Bot is ready. Guild/Channel: {TARGET_GUILD_ID}/{TARGET_CHANNEL_ID}, {dt.datetime.now()}")
 
     # 対象ギルドとチャンネルを設定
     for guild in bot.guilds:

--- a/bot/utils/checker.py
+++ b/bot/utils/checker.py
@@ -42,79 +42,81 @@ async def check(bot):
     if updating:
         print("更新確認は既に実行中です。")
         return
-    updating = True
-    print(f"更新確認開始: {dt.datetime.now()}")
-    data = _load_json('save_info.json')
-    channel = bot.get_channel(CHANNEL_ID)
-    del_workid_list = []
+    try: 
+        updating = True
+        print(f"更新確認開始: {dt.datetime.now()}")
+        data = _load_json('save_info.json')
+        channel = bot.get_channel(CHANNEL_ID)
+        del_workid_list = []
 
-    for idx, item in enumerate(data):
-        await bot.change_presence(activity=discord.Activity(name=f"更新確認中...({idx+1}/{len(data)})", type=discord.ActivityType.playing))
-        work_id = item['work_id']
-        latest_update_date_dt = dt.datetime.strptime(
-            item['latest_update_date'], "%Y-%m-%d %H:%M:%S"
-        )
-        try:
-            # 最新データ取得
-            info = await fetch_initial_data(int(work_id))
-        except selenium.common.exceptions.TimeoutException as e:
-            continue
-        
-        # 取得できなかった場合はスキップ
-        if not info:
-            print(f"作品ID {work_id} の情報が取得できませんでした。スキップします。")
-            continue
-
-        # 変化があれば通知
-        if info['latest_part_id'] != item.get('latest_part_id'):
-            item.update(info)
-            url = f"https://animestore.docomo.ne.jp/animestore/ci_pc?workId={work_id}&partId={info['latest_part_id']}"
-            embed = Embed(
-                title="以下のアニメが更新されました。",
-                description=f"{info['work_title']}\n第{int(info['latest_part_id'][-3:])}話: {info['latest_part_title']}\n{url}",
-                color=0xff4500
+        for idx, item in enumerate(data):
+            await bot.change_presence(activity=discord.Activity(name=f"更新確認中...({idx+1}/{len(data)})", type=discord.ActivityType.playing))
+            work_id = item['work_id']
+            latest_update_date_dt = dt.datetime.strptime(
+                item['latest_update_date'], "%Y-%m-%d %H:%M:%S"
             )
-            embed.set_image(url=info['latest_part_thumbnail_url'])
-            await channel.send(embed=embed)
-        else:
-            # 2週間と1日以上更新がない場合は削除
-            if dt.datetime.now() - latest_update_date_dt > dt.timedelta(days=15):
-                del_workid_list.append(work_id)
-            # スケジュール更新のみ
-            item['schedule_day'] = info['schedule_day']
-            item['schedule_time'] = info['schedule_time']
-    
-    # 差分マージ（確認処理中に追加削除されたものに対応）
-    orig_ids = {item['work_id'] for item in data}
-    latest_file = _load_json('save_info.json')
-    latest_ids  = {it['work_id'] for it in latest_file}
+            try:
+                # 最新データ取得
+                info = await fetch_initial_data(int(work_id))
+            except selenium.common.exceptions.TimeoutException as e:
+                continue
+            
+            # 取得できなかった場合はスキップ
+            if not info:
+                print(f"作品ID {work_id} の情報が取得できませんでした。スキップします。")
+                continue
 
-    # 途中で追加された作品を確認
-    added_ids = latest_ids - orig_ids
-    if added_ids:
-        print("途中追加を確認:", added_ids)
-        for it in latest_file:
-            if it['work_id'] in added_ids:
-                data.append(it)
+            # 変化があれば通知
+            if info['latest_part_id'] != item.get('latest_part_id'):
+                item.update(info)
+                url = f"https://animestore.docomo.ne.jp/animestore/ci_pc?workId={work_id}&partId={info['latest_part_id']}"
+                embed = Embed(
+                    title="以下のアニメが更新されました。",
+                    description=f"{info['work_title']}\n第{int(info['latest_part_id'][-3:])}話: {info['latest_part_title']}\n{url}",
+                    color=0xff4500
+                )
+                embed.set_image(url=info['latest_part_thumbnail_url'])
+                await channel.send(embed=embed)
+            else:
+                # 2週間と1日以上更新がない場合は削除
+                if dt.datetime.now() - latest_update_date_dt > dt.timedelta(days=15):
+                    del_workid_list.append(work_id)
+                # スケジュール更新のみ
+                item['schedule_day'] = info['schedule_day']
+                item['schedule_time'] = info['schedule_time']
+        
+        # 差分マージ（確認処理中に追加削除されたものに対応）
+        orig_ids = {item['work_id'] for item in data}
+        latest_file = _load_json('save_info.json')
+        latest_ids  = {it['work_id'] for it in latest_file}
 
-    # 途中で削除された作品を確認
-    removed_ids = orig_ids - latest_ids
-    if removed_ids:
-        print("途中削除を確認:", removed_ids)
-        data = [it for it in data if it['work_id'] not in removed_ids] 
-    
-    # 自動削除リストに載った作品を削除
-    if del_workid_list:
-        print("自動削除対象:", del_workid_list)
-        # save_info.json から削除
-        data = [item for item in data if item['work_id'] not in del_workid_list]
+        # 途中で追加された作品を確認
+        added_ids = latest_ids - orig_ids
+        if added_ids:
+            print("途中追加を確認:", added_ids)
+            for it in latest_file:
+                if it['work_id'] in added_ids:
+                    data.append(it)
 
-    _save_json('save_info.json', data)
-    updating = False
-    await bot.change_presence(
-        activity=discord.Activity(
-            name="dアニメストアを30分に1回確認します。", 
-            type=discord.ActivityType.playing
+        # 途中で削除された作品を確認
+        removed_ids = orig_ids - latest_ids
+        if removed_ids:
+            print("途中削除を確認:", removed_ids)
+            data = [it for it in data if it['work_id'] not in removed_ids] 
+        
+        # 自動削除リストに載った作品を削除
+        if del_workid_list:
+            print("自動削除対象:", del_workid_list)
+            # save_info.json から削除
+            data = [item for item in data if item['work_id'] not in del_workid_list]
+
+        _save_json('save_info.json', data)
+    finally: 
+        updating = False
+        await bot.change_presence(
+            activity=discord.Activity(
+                name="dアニメストアを30分に1回確認します。", 
+                type=discord.ActivityType.playing
+            )
         )
-    )
-    print(f"更新確認終了: {dt.datetime.now()}")
+        print(f"更新確認終了: {dt.datetime.now()}")

--- a/bot/utils/scraper.py
+++ b/bot/utils/scraper.py
@@ -2,6 +2,7 @@ import asyncio
 import datetime as dt
 from discord import Embed
 import re
+import random
 import os
 from selenium import webdriver
 from selenium.webdriver.common.by import By
@@ -30,7 +31,9 @@ async def fetch_initial_data(work_id: int) -> dict:
     modal_body = wait.until(EC.presence_of_element_located(
     (By.CSS_SELECTOR, "span.note.schedule")
     ))
-    await asyncio.sleep(5)
+    random_sleep_time = random.uniform(1.5, 8.5) 
+    await asyncio.sleep(random_sleep_time)  # ランダムな待機時間を追加
+    
     html = driver.page_source
     soup = BeautifulSoup(html, 'html.parser')
     driver.quit()
@@ -60,6 +63,8 @@ async def fetch_initial_data(work_id: int) -> dict:
         pid = re.search(r"=(\d{8})", a["href"]).group(1)
         # リンクの次にある span を探す（エピソードタイトル）
         title_span = a.find_next("span", class_="ui-clamp webkit2LineClamp")
+        if not title_span:
+            continue
         title = title_span.text.strip()
         episodes.append((pid, title))
 

--- a/bot/utils/storage.py
+++ b/bot/utils/storage.py
@@ -40,6 +40,11 @@ async def add_to_watchlist(ctx, work_id: int):
     # 初期情報取得（fetch_initial_dataは scraper.py で定義）
     from bot.utils.scraper import fetch_initial_data
     info = await fetch_initial_data(work_id)
+    if not info:
+        await ctx.send(embed=Embed(
+            title="アニメタイトルの追加に失敗しました。", color=0xff4500
+        ), delete_after=60)
+        return
     save_data.append(info)
     _save_json('save_info.json', save_data)
     url = f"https://animestore.docomo.ne.jp/animestore/ci_pc?workId={work_id}"


### PR DESCRIPTION
## 不具合の修正
- 常に更新確認中状態になる不具合の修正

## 軽微な変更
- bot起動時に時刻もあわせて標準出力するように変更
- 更新確認時のスリープを5秒固定ではなくランダムな秒数に変更